### PR TITLE
Automatically generated patch for magento/magento2#32698

### DIFF
--- a/patches.json
+++ b/patches.json
@@ -129,7 +129,7 @@
     },
     "MDVA-30106": {
         "magento/magento2-base": {
-            "Fixes the issue where during checkout, payments are not loaded with “Cannot read property ‘length’ of null ” error in JS console.": {
+            "Fixes the issue where during checkout, payments are not loaded with \u201cCannot read property \u2018length\u2019 of null \u201d error in JS console.": {
                 "^2.3.0": {
                     "file": "os/MDVA-30106_2.3.4.patch"
                 }
@@ -1882,6 +1882,15 @@
                 },
                 ">=2.4.2 <2.4.3": {
                     "file": "os/MC-41359_2.4.2.patch"
+                }
+            }
+        }
+    },
+    "magento/magento2/32698": {
+        "magento2-base": {
+            "Take required product attributes into account when caching used products": {
+                "2.4.1": {
+                    "file": "community/magento_magento2_32698.patch"
                 }
             }
         }

--- a/patches/community/magento_magento2_32698.patch
+++ b/patches/community/magento_magento2_32698.patch
@@ -1,0 +1,92 @@
+From 7d80db88b9998bb564d553000d7a7881e3d95727 Mon Sep 17 00:00:00 2001
+From: Maikel Koek <maikel@h-o.nl>
+Date: Fri, 9 Apr 2021 14:37:25 +0200
+Subject: [PATCH 1/2] Take required product attributes into account when
+ caching used products
+
+---
+ .../Model/Product/Type/Configurable.php        | 14 ++++++++++----
+ .../Model/Product/Type/ConfigurableTest.php    | 18 ++++++++++++++++++
+ 2 files changed, 28 insertions(+), 4 deletions(-)
+
+diff --git a/vendor/magento/module-configurable-product/Model/Product/Type/Configurable.php b/vendor/magento/module-configurable-product/Model/Product/Type/Configurable.php
+index 79f6d1e47f1a..ec075dbf99aa 100644
+--- a/vendor/magento/module-configurable-product/Model/Product/Type/Configurable.php
++++ b/vendor/magento/module-configurable-product/Model/Product/Type/Configurable.php
+@@ -1290,13 +1290,19 @@ public function isPossibleBuyFromList($product)
+      */
+     public function getUsedProducts($product, $requiredAttributeIds = null)
+     {
+-        if (!$product->hasData($this->_usedProducts)) {
+-            $collection = $this->getConfiguredUsedProductCollection($product, false, $requiredAttributeIds);
++        $requiredAttributeIds = $requiredAttributeIds ?: [];
++        array_unshift($requiredAttributeIds, $product->getId());
++
++        $cacheKey = $this->getUsedProductsCacheKey($requiredAttributeIds);
++        if (!$product->hasData($this->_usedProducts) || !isset($product->getData($this->_usedProducts)[$cacheKey])) {
++            $collection = $this->getConfiguredUsedProductCollection($product, true, $requiredAttributeIds);
+             $usedProducts = array_values($collection->getItems());
+-            $product->setData($this->_usedProducts, $usedProducts);
++            $usedProductsCache = $product->getData($this->_usedProducts);
++            $usedProductsCache[$cacheKey] = $usedProducts;
++            $product->setData($this->_usedProducts, $usedProductsCache);
+         }
+ 
+-        return $product->getData($this->_usedProducts);
++        return $product->getData($this->_usedProducts)[$cacheKey];
+     }
+ 
+     /**
+diff --git a/dev/tests/integration/testsuite/Magento/ConfigurableProduct/Model/Product/Type/ConfigurableTest.php b/dev/tests/integration/testsuite/Magento/ConfigurableProduct/Model/Product/Type/ConfigurableTest.php
+index 4b6fac496df0..fbab458cd928 100644
+--- a/dev/tests/integration/testsuite/Magento/ConfigurableProduct/Model/Product/Type/ConfigurableTest.php
++++ b/dev/tests/integration/testsuite/Magento/ConfigurableProduct/Model/Product/Type/ConfigurableTest.php
+@@ -283,6 +283,24 @@ public function testGetUsedProductsWithoutRequiredAttributes()
+         }
+     }
+ 
++    /**
++     * @magentoAppIsolation enabled
++     * @magentoDataFixture Magento/ConfigurableProduct/_files/product_configurable_with_metadescription.php
++     */
++    public function testGetUsedProductsWithoutAndWithRequiredAttributes()
++    {
++        $products = $this->model->getUsedProducts($this->product);
++        foreach ($products as $product) {
++            self::assertNull($product->getData('meta_description'));
++        }
++
++        $requiredAttributeIds = [86];
++        $products = $this->model->getUsedProducts($this->product, $requiredAttributeIds);
++        foreach ($products as $product) {
++            self::assertNotNull($product->getData('meta_description'));
++        }
++    }
++
+     /**
+      * Test getUsedProducts returns array with same indexes regardless collections was cache or not.
+      *
+
+From d86a28751d286dc42d2561093ed3841e6edff085 Mon Sep 17 00:00:00 2001
+From: Maikel Koek <maikel@h-o.nl>
+Date: Mon, 12 Apr 2021 10:39:24 +0200
+Subject: [PATCH 2/2] reverted arguments of getConfiguredUsedProductCollection
+
+$skipStockFilter was accidentally changed to true
+---
+ .../ConfigurableProduct/Model/Product/Type/Configurable.php     | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/vendor/magento/module-configurable-product/Model/Product/Type/Configurable.php b/vendor/magento/module-configurable-product/Model/Product/Type/Configurable.php
+index ec075dbf99aa..6a36c3652994 100644
+--- a/vendor/magento/module-configurable-product/Model/Product/Type/Configurable.php
++++ b/vendor/magento/module-configurable-product/Model/Product/Type/Configurable.php
+@@ -1295,7 +1295,7 @@ public function getUsedProducts($product, $requiredAttributeIds = null)
+ 
+         $cacheKey = $this->getUsedProductsCacheKey($requiredAttributeIds);
+         if (!$product->hasData($this->_usedProducts) || !isset($product->getData($this->_usedProducts)[$cacheKey])) {
+-            $collection = $this->getConfiguredUsedProductCollection($product, true, $requiredAttributeIds);
++            $collection = $this->getConfiguredUsedProductCollection($product, false, $requiredAttributeIds);
+             $usedProducts = array_values($collection->getItems());
+             $usedProductsCache = $product->getData($this->_usedProducts);
+             $usedProductsCache[$cacheKey] = $usedProducts;


### PR DESCRIPTION
### Title
Take required product attributes into account when caching used products

### Patch Description
Pull request is automatically generated and contains Magento composer based installation patch based on magento/magento2#1231 pull request provided by @user

### Patch Category
Performance

### Supported version(s)
2.3.7<2.4.1

### Affected Files